### PR TITLE
Include device type in launch.json

### DIFF
--- a/ioc2cmake.py
+++ b/ioc2cmake.py
@@ -154,6 +154,7 @@ if __name__ == "__main__":
                         "request": "attach",
                         "type": "cortex-debug",
                         "servertype": "openocd",
+                        "device": iocConf["Mcu.UserName"],
                         "configFiles": [
                             "${workspaceRoot}/openocd.cfg"
                         ]


### PR DESCRIPTION
This allows for the Cortex-Debug extension in VSCode to automatically determine the proper SVD File.
An alternative would be to specify the SVD file path directly, though that path is not given as part of the IOC file.